### PR TITLE
Add dotenv for reading .env file

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('dotenv').config();
+
 var SlackBot  = require( 'slackbots' );
 var ghget     = require( 'github-get' );
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/radibit/js-tips-slack-bot.git"
   },
   "scripts": {
-    "start" : "node app.js"
+    "start": "node app.js"
   },
   "keywords": [
     "slackbot",
@@ -22,6 +22,7 @@
     "url": "https://github.com/radibit/js-tips-slack-bot/issues"
   },
   "dependencies": {
+    "dotenv": "^2.0.0",
     "github-get": "^0.3.1",
     "slackbots": "^0.5.1"
   }


### PR DESCRIPTION
There's an error when I try `npm run start` because a Slack bot token isn't defined.

<img width="710" alt="token_not_define" src="https://cloud.githubusercontent.com/assets/7040242/13193819/1029c40e-d7b2-11e5-998f-80aecdc8e22e.png">

I investigated and found out that `process.env.SLACK_TOKEN` can't be read.

I use [dotenv](https://github.com/motdotla/dotenv) to solve that.
